### PR TITLE
Fix broken 'myPromise' error message

### DIFF
--- a/src/3-practical-guidance.md
+++ b/src/3-practical-guidance.md
@@ -86,8 +86,8 @@ const myPromise: Promise<{}> = dontCarePromise();
 
 …then it broke on TS 3.5, with the compiler reporting an error ([playground][3.5-breakage-plaground]):
 
-> Type 'Promise<unknown>' is not assignable to type 'Promise<{}>'.
->   Type 'unknown' is not assignable to type '{}'.
+    Type 'Promise<unknown>' is not assignable to type 'Promise<{}>'.
+      Type 'unknown' is not assignable to type '{}'.
 
 This change could be mitigated by supplying a default type argument equal to the original value ([playground][3.5-mitigation-playground]):
 

--- a/src/3-practical-guidance.md
+++ b/src/3-practical-guidance.md
@@ -86,8 +86,10 @@ const myPromise: Promise<{}> = dontCarePromise();
 
 …then it broke on TS 3.5, with the compiler reporting an error ([playground][3.5-breakage-plaground]):
 
-    Type 'Promise<unknown>' is not assignable to type 'Promise<{}>'.
-      Type 'unknown' is not assignable to type '{}'.
+```plain
+Type 'Promise<unknown>' is not assignable to type 'Promise<{}>'.
+  Type 'unknown' is not assignable to type '{}'.
+```
 
 This change could be mitigated by supplying a default type argument equal to the original value ([playground][3.5-mitigation-playground]):
 


### PR DESCRIPTION
Today, it's rendered like this:

> Type 'Promise' is not assignable to type 'Promise<{}>'. Type 'unknown' is not assignable to type '{}'.

The multi-line formatting and indentation are lost, along with `<unknown>` (which I assume is interpreted as an HTML tag by the Markdown parser).

With this change, it's instead rendered like this:

    Type 'Promise<unknown>' is not assignable to type 'Promise<{}>'.
      Type 'unknown' is not assignable to type '{}'.