### PR TITLE
Fix broken footnotes

### DIFF
--- a/src/formal-spec/2-breaking-changes.md
+++ b/src/formal-spec/2-breaking-changes.md
@@ -156,19 +156,3 @@ For functions which return or accept user-constructible types, the rules specifi
 [remove-required-argument]: https://www.typescriptlang.org/play/?ssl=2&ssc=35&pln=2&pc=47#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwAc4A3XZAZwAooAuecjGLVAcwBp4AjO1ZAW04gYASjrEcWYAG4AUKEiwEKdNjzxkBYFAwhg1OgyatR8cZNkyIIDPCjwAvIRJkqAcgI4M2nK44BGACZhWSsbTgd1TW1dSndPb194QOCgA
 
 [remove-optional-argument]: https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwAc4A3XZAZwAooAuecjGLVAcwBp4AjAfjtWQC2nEDACUdYjizAA3AChQkWAhTpseeMgLAoGEMGp0GTVuPiTp8uRBAZ4UeAF5CJMlQDkBHBl053HAEYAJlF5GztOJ01tXX1KT29ff3hg0OtbeDAoohBSHAp4rx8MPzTw+GAorR09AwTi0vkgA
-
-
----
-
-
-## Notes
-
-[^variance]: For the purposes of this discussion, I will *assume* knowledge of variance, rather than explaining it.
-
-[^satisficery]: Precisely because SemVer is a *sociological* and not only a *technical* contract, the problem is tractable: We define a breaking change as above, and accept the reality that some changes are not preventable (but may in many cases be mitigated or fixed automatically). This is admittedly unsatisfying, but we believe it [satisfices](https://www.merriam-webster.com/dictionary/satisfice) our constraints.
-
-[^thanks-to-ryan]: Thanks to [Ryan Cavanaugh](https://github.com/RyanCavanaugh) of the TypeScript team for pointing out the various examples which motivated this discussion.
-
-[^nit-on-comparability]: Strictly speaking, one value may stop being comparable to another value in this scenario. However, this is both a rare edge case and fits under the standard rule where changes which simply let users delete now-defunct code are allowed.
-
-[^variance-in-discriminating]: Mostly, anyway—see [Appendix C: On Variance in TypeScript – Higher-order type operations](#higher-order-type-operations) below for a discussion of how the `in` operator (or similar operations discriminating between unions) makes this cause breakage in some cases. These are rare enough, and easily-enough solved, that the rule remains workable.

--- a/src/formal-spec/3-non-breaking-changes.md
+++ b/src/formal-spec/3-non-breaking-changes.md
@@ -47,3 +47,9 @@ For functions which return or accept user-constructible types, the rules specifi
 
 [optional-argument]: https://www.typescriptlang.org/play/#code/CYUwxgNghgTiAEAzArgOzAFwJYHtXwAc4A3XZAZwAooAuecjGLVAcwBp4AjO1ZAW04gYASjrEcWYAG4AUKEiwEKdNjzxkBYFAwhg1OgyasOnAPw9+gkWInSZMiCAzwo8ALyESZKgHICODG0cHw4ARgAmYVlHZ053dU1tXUo-AKCQ+AiooA
 
+
+## Notes
+
+[^nit-on-comparability]: Strictly speaking, one value may stop being comparable to another value in this scenario. However, this is both a rare edge case and fits under the standard rule where changes which simply let users delete now-defunct code are allowed.
+
+[^variance-in-discriminating]: Mostly, anyway—see [Appendix C: On Variance in TypeScript – Higher-order type operations](#higher-order-type-operations) below for a discussion of how the `in` operator (or similar operations discriminating between unions) makes this cause breakage in some cases. These are rare enough, and easily-enough solved, that the rule remains workable.

--- a/src/formal-spec/index.md
+++ b/src/formal-spec/index.md
@@ -43,3 +43,12 @@ Accordingly, we propose the rules below, with the caveat that (as noted in sever
 
 
 For a more detailed explanation and analysis of the impact of variance on these rules, see [**Appendix C: Variance in TypeScript**](../appendices/c-variance-in-typescript.md).
+
+
+## Notes
+
+[^variance]: For the purposes of this discussion, I will *assume* knowledge of variance, rather than explaining it.
+
+[^thanks-to-ryan]: Thanks to [Ryan Cavanaugh](https://github.com/RyanCavanaugh) of the TypeScript team for pointing out the various examples which motivated this discussion.
+
+[^satisficery]: Precisely because SemVer is a *sociological* and not only a *technical* contract, the problem is tractable: We define a breaking change as above, and accept the reality that some changes are not preventable (but may in many cases be mitigated or fixed automatically). This is admittedly unsatisfying, but we believe it [satisfices](https://www.merriam-webster.com/dictionary/satisfice) our constraints.


### PR DESCRIPTION
Some footnote references don't refer to any footnote; they are instead rendered like this:

> In a real sense, everything in the discussion below is a way of showing the variance rules by example.[^thanks-to-ryan]

I believe they were broken by f70f1f42, based on the output of this command before and after that commit:

```bash
for footnoteRef in $(git grep -h --only-matching --perl-regexp '\[\^[^]]+\]' | sort | uniq); do
  echo
  echo "=== $footnoteRef ==="
  git grep --count -F $footnoteRef
done
```

When I had fixed the broken footnote references by moving the footnotes themselves, I noticed that f70f1f42 had also swapped the order of the `thanks-to-ryan` and `satisficery` footnotes, causing them to end up in the "wrong" order (1, 3, 2 instead of 1, 2, 3). This PR undoes that reordering.

Finally, I deliberately didn't preserve the `---` line before `## Notes` because no other `## Notes` section is preceded by such a line, based on the output of this command:

```bash
git grep -B 3 '## Notes'
```

💡 `git show --color-moved` is useful.